### PR TITLE
fix: properly encrypt IPv6 endpoints

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -305,6 +305,7 @@ func clusterSimulator(t *testing.T, endpoint string, logger *zap.Logger, numAffi
 			},
 			Endpoints: []*clientpb.Endpoint{
 				{
+					Ip:   make([]byte, 4), // IPv4
 					Port: uint32((i + 1) * 10),
 				},
 			},
@@ -313,6 +314,7 @@ func clusterSimulator(t *testing.T, endpoint string, logger *zap.Logger, numAffi
 				AffiliateID: fmt.Sprintf("affiliate-%d", (i+1)%numAffiliates),
 				Endpoints: []*clientpb.Endpoint{
 					{
+						Ip:   make([]byte, 16), // IPv6
 						Port: uint32(((i+1)%numAffiliates + 1) * 100),
 					},
 				},


### PR DESCRIPTION
I somehow assumes AES block size is equal to key size (32 bytes), but
that is not the fact. AES block size is always 16 bytes, so for IPv6
endpoints (and longer endpoints in general) we have to encrypt every
block.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>