### PR TITLE
fix: retry on Hello failures

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -275,6 +275,9 @@ func (client *Client) Run(ctx context.Context, logger *zap.Logger, notifyCh chan
 			newEndpoint, err := client.sendHello(ctx, discoveryClient)
 			if err != nil {
 				logger.Error("hello failed", zap.Error(err), zap.String("endpoint", client.options.Endpoint))
+
+				// retry hello request until it succeeds
+				continue
 			}
 
 			if newEndpoint != "" {


### PR DESCRIPTION
Client shouldn't go into Watch mode if Hello failed.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>